### PR TITLE
Optimize memory usage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,13 @@
+pub mod stream_range;
+pub mod serve_range;
+pub mod zip;
+pub mod upstream;
+pub mod s3url;
+
+
+#[derive(Clone)]
+pub struct Config {
+    pub upstream: String,
+    pub strip_prefix: String,
+    pub via_zip_stream_header_value: String,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,7 @@ async fn handle_request(req: Request<Body>, client: &HyperClient, s3_client: s3:
             (StatusCode::SERVICE_UNAVAILABLE, "Upstream request failed")
         })?;
 
-        upstream::response(s3_client, &req, &body[..])
+        upstream::response(s3_client, &req, body)
     } else {
         log::info!("Request proxied from upstream");
         Ok(upstream_res)

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,10 @@
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3 as s3;
 
-mod stream_range;
-mod serve_range;
-mod zip;
-mod upstream;
-mod s3url;
+use zipstream::{
+    upstream,
+    Config
+};
 
 use std::convert::Infallible;
 
@@ -16,13 +15,6 @@ use hyper::service::{ make_service_fn, service_fn };
 use hyper_tls::HttpsConnector;
 
 type HyperClient = Client<HttpsConnector<HttpConnector>>;
-
-#[derive(Clone)]
-pub struct Config {
-    upstream: String,
-    strip_prefix: String,
-    via_zip_stream_header_value: String,
-}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,9 @@ use hyper::{ Client, Request, Response, Body, Server, StatusCode, client::HttpCo
 use hyper::service::{ make_service_fn, service_fn };
 use hyper_tls::HttpsConnector;
 
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 type HyperClient = Client<HttpsConnector<HttpConnector>>;
 
 #[tokio::main]


### PR DESCRIPTION
This results in an ~6x reduction in peak memory when streaming a zip file with 20k entries.

* Jemallocator was included as a dependency, but not actually turned on.
* The large S3 read futures were all allocated ahead of time; this makes them lazily allocated since only one S3 object is being downloaded at a time per stream.
* Once the manifest is parsed, the unparsed JSON text can be discarded.