### PR TITLE
Improve error logging for Hyper 1.0

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,18 @@
+use std::{error::Error, fmt::{self, Display}};
+
+/// Helper for displaying errors with their sources
+pub struct Report<T>(pub T);
+impl<T: Error> Display for Report<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut error: &dyn Error = &self.0;
+
+        write!(f, "{}", error)?;
+
+        while let Some(source) = error.source() {
+            write!(f, "\n  : {source}")?;
+            error = source;
+        }
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod serve_range;
 pub mod zip;
 pub mod upstream;
 pub mod s3url;
+pub mod error;
 
 
 #[derive(Clone)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,6 @@ use bytes::Bytes;
 use http_body_util::{BodyExt, Either};
 use hyper::server::conn::http1;
 use hyper_util::rt::{TokioIo, TokioExecutor};
-use log::error;
 use tokio::net::TcpListener;
 use zipstream::{
     upstream,
@@ -93,7 +92,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 }}))
                 .await
             {
-                error!("Error serving connection: {}", Report(err));
+                log::warn!("Error serving connection: {}", Report(err));
             }
         });
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,8 @@ use log::error;
 use tokio::net::TcpListener;
 use zipstream::{
     upstream,
-    Config, stream_range::BoxError
+    Config, stream_range::BoxError,
+    error::Report,
 };
 
 use std::net::SocketAddr;
@@ -92,7 +93,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 }}))
                 .await
             {
-                error!("Error serving connection: {err}");
+                error!("Error serving connection: {}", Report(err));
             }
         });
     }
@@ -110,13 +111,13 @@ async fn handle_request(
     log::info!("Request: {} {}", req.method(), req.uri());
     let upstream_req = upstream::request(config, &req)?;
     let upstream_res = client.request(upstream_req).await.map_err(|e| {
-        log::error!("Failed to connect upstream: {}", e);
+        log::error!("Failed to connect upstream: {}", Report(e));
         (StatusCode::SERVICE_UNAVAILABLE, "Upstream connection failed")
     })?;
 
     if upstream_res.headers().get("X-Zip-Stream").is_some() {
         let body = upstream_res.into_body().collect().await.map_err(|e| {
-            log::error!("Failed to read upstream body: {}", e);
+            log::error!("Failed to read upstream body: {}", Report(e));
             (StatusCode::SERVICE_UNAVAILABLE, "Upstream request failed")
         })?;
 

--- a/src/serve_range.rs
+++ b/src/serve_range.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use futures::{stream::TryStreamExt, StreamExt};
 use http_body_util::StreamBody;
 use hyper::{Request, Response, body::{Body, Frame}, StatusCode, header};
-use crate::stream_range::{ Range, StreamRange, BoxError };
+use crate::{error::Report, stream_range::{ BoxError, Range, StreamRange }};
 
 /// Parse an HTTP range header to a `Range`
 ///
@@ -102,7 +102,7 @@ pub fn hyper_response(req: &Request<impl Body>, content_type: &str, etag: &str, 
     res = res.header(header::CONTENT_LENGTH, range.len());
 
     let stream = data.stream_range(range).inspect_err(|err| {
-        log::error!("Response stream error: {}", err);
+        log::error!("Response stream error: {}", Report(&**err));
     });
 
     res.body(StreamBody::new(stream.map(|chunk| chunk.map(Frame::data)))).unwrap()


### PR DESCRIPTION
This is currently logging errors like `Error serving connection: connection error` every time someone cancels a download. This reduces the noisy errors to `warn` level, and adds additional detail by including the chain of `source` errors.